### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/backend/awscloudformation/nested-cloudformation-stack.yml
+++ b/amplify/backend/awscloudformation/nested-cloudformation-stack.yml
@@ -251,7 +251,7 @@
 					}
 				},
 				"Handler": "index.handler",
-				"Runtime": "nodejs10.x",
+				"Runtime": "nodejs14.x",
 				"Timeout": "300",
 				"Role": {
 					"Fn::GetAtt": [

--- a/amplify/backend/function/chimevcagentassist76fdc921/chimevcagentassist76fdc921-cloudformation-template.json
+++ b/amplify/backend/function/chimevcagentassist76fdc921/chimevcagentassist76fdc921-cloudformation-template.json
@@ -96,7 +96,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs14.x",
         "Timeout": "300"
       },
       "Type": "AWS::Lambda::Function"
@@ -191,7 +191,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs10.x",
+				"Runtime": "nodejs14.x",
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "amplify-chime-vc-agentassist-zhizhk-94343-deployment",


### PR DESCRIPTION
CloudFormation templates in chime-voiceconnector-agent-assist have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.