### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/amplify/backend/auth/cognitocf0c6096/cognitocf0c6096-cloudformation-template.yml
+++ b/amplify/backend/auth/cognitocf0c6096/cognitocf0c6096-cloudformation-template.yml
@@ -435,7 +435,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs12.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/infrastructure/deployment-template.json
+++ b/infrastructure/deployment-template.json
@@ -280,7 +280,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 3,
         "Events": {
             "CWEvent": {
@@ -340,7 +340,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 3,
         "FunctionName": "chime-s3-audio-streaming"
       },
@@ -370,7 +370,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 3
       },
       "Type": "AWS::Serverless::Function"
@@ -398,7 +398,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 3,
         "Events": {
             "CWEvent": {


### PR DESCRIPTION
CloudFormation templates in chime-voiceconnector-agent-assist have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.